### PR TITLE
Upgrade to reCAPTCHA v2

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Captcha plugin powered by reCaptcha: <http://recaptcha.net/>.
+Captcha plugin powered by reCaptcha: <https://developers.google.com/recaptcha/>.
 
 
 ## Requirements
@@ -18,7 +18,7 @@ Captcha plugin powered by reCaptcha: <http://recaptcha.net/>.
 
 ## Features
 
-* Provides captcha powered by reCaptcha.
+* Provides captcha powered by reCaptcha v2.
 
 
 ## Documentation

--- a/plugins/reCaptcha/php/init.reCaptcha.php
+++ b/plugins/reCaptcha/php/init.reCaptcha.php
@@ -40,20 +40,18 @@ class reCaptcha extends BaseCaptchaProvider {
         }
 
         $fields = "
-<div id=\"recaptcha_script\" style=\"display:block\">
 <script type=\"text/javascript\"
-   src=\"http://api.recaptcha.net/challenge?k=$publickey\">
+   src=\"//www.google.com/recaptcha/api.js\" async defer>
 </script>
+<div id=\"recaptcha_script\" class=\"g-recaptcha\" data-sitekey=\"$publickey\">
+</div>
 
 <noscript>
-   <iframe src=\"http://api.recaptcha.net/noscript?k=$publickey\"
-       height=\"300\" width=\"500\" frameborder=\"0\"></iframe><br>
-   <textarea name=\"recaptcha_challenge_field\" rows=\"3\" cols=\"40\">
-   </textarea>
-   <input type=\"hidden\" name=\"recaptcha_response_field\"
-       value=\"manual_challenge\">
+   <iframe src=\"//www.google.com/recaptcha/api/fallback?k=$publickey\"
+       height=\"302\" width=\"422\" frameborder=\"0\"></iframe><br>
+   <textarea id=\"g-recaptcha-response\" name=\"g-recaptcha-response\"
+       class=\"g-recaptcha-response\"></textarea>
 </noscript>
-</div>
 <script type=\"text/javascript\">
 if ( typeof(mtCaptchaVisible) != \"undefined\" )
     mtCaptchaVisible = true;

--- a/plugins/reCaptcha/reCaptcha.pl
+++ b/plugins/reCaptcha/reCaptcha.pl
@@ -44,7 +44,7 @@ TMPL
         ['recaptcha_publickey', { Scope   => 'blog' }],
         ['recaptcha_privatekey', { Scope   => 'blog' }],
     ]),
-    version => '0.3',
+    version => '0.4',
 });
 
 MT->add_plugin($plugin);


### PR DESCRIPTION
Upgraded to reCAPTCHA v2 based on [this documentation](https://developers.google.com/recaptcha/docs/verify#api-response), updated some links, and bumped the plugin’s version number.

The updated `<noscript>` form is loosely based on [this FAQ entry](https://developers.google.com/recaptcha/docs/faq#does-recaptcha-support-users-that-dont-have-javascript-enabled), but without all the style attributes, since it would be better to give site templates more control over the appearance of that form.

Fixes #5.